### PR TITLE
Remove shard_id label for hook metrics that do not have a shard ID

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ misspell-correction:
 
 .PHONY: staticcheck
 staticcheck:
-	export GOFLAGS=$(GOMOD) && $(STATICCHECK) ./...
+	GOFLAGS=$(GOMOD) $(STATICCHECK) ./...
 
 .PHONY: vet
 vet:

--- a/exporter/omnishard/encoder.go
+++ b/exporter/omnishard/encoder.go
@@ -96,8 +96,8 @@ type shardEncoders []*shardEncoder
 
 // Options are the options to be used when initializing an encoder.
 type Options struct {
-	// TODO: document this field.
-	Name string
+	// ExporterName is the name of the exporter using the encoder.
+	ExporterName string
 
 	// Number of workers that will feed spans to shard encoders concurrently.
 	// Minimum and default value is 1.
@@ -155,7 +155,7 @@ func newEncoder(
 		logger:               logger,
 		onRecordReady:        onRecordReady,
 		onSpanProcessFail:    onSpanProcessFail,
-		hooks:                newTelemetryHooks(o.Name, ""),
+		hooks:                newTelemetryHooks(o.ExporterName, ""),
 		configChangeCond:     sync.NewCond(&sync.Mutex{}),
 		workerHardStopSignal: make(chan interface{}),
 	}
@@ -358,7 +358,7 @@ func (e *encoder) startShardEncoders(cfg *shardingInMemConfig) {
 	encoders := make(shardEncoders, 0, len(cfg.shards))
 	for _, shard := range cfg.shards {
 		// Create hooks to report per-shard operations.
-		hooks := newTelemetryHooks(o.Name, shard.shardID)
+		hooks := newTelemetryHooks(o.ExporterName, shard.shardID)
 		encoders = append(encoders, newShardEncoder(
 			e.logger,
 			shard,

--- a/exporter/omnishard/exporter.go
+++ b/exporter/omnishard/exporter.go
@@ -99,6 +99,7 @@ func NewExporter(cfg *Config, logger *zap.Logger, client client) (*Exporter, err
 	}
 
 	opt := &Options{
+		ExporterName:          cfg.Name(),
 		NumWorkers:            cfg.NumWorkers,
 		MaxAllowedSizePerSpan: cfg.MaxAllowedSizePerSpan,
 		BatchFlushInterval:    cfg.BatchFlushInterval,

--- a/exporter/omnishard/hooks.go
+++ b/exporter/omnishard/hooks.go
@@ -50,16 +50,16 @@ type telemetryHooks struct {
 	dropSendErrNotRetryableTags        []tag.Mutator
 }
 
-func newTelemetryHooks(name, shardID string) *telemetryHooks {
+func newTelemetryHooks(exporterName, shardID string) *telemetryHooks {
 	tags := []tag.Mutator{
-		tag.Upsert(tagExporterName, name),
+		tag.Upsert(tagExporterName, exporterName),
 	}
 	if shardID != "" {
 		tags = append(tags, tag.Upsert(tagShardID, shardID))
 	}
 
 	h := &telemetryHooks{
-		exporterName: name,
+		exporterName: exporterName,
 		commonTags:   tags,
 	}
 

--- a/exporter/omnishard/telemetry.go
+++ b/exporter/omnishard/telemetry.go
@@ -48,7 +48,8 @@ var (
 
 // MetricViews return the metrics views according to given telemetry level.
 func metricViews() []*view.View {
-	tagKeys := []tag.Key{tagExporterName, tagShardID}
+	exporterTags := []tag.Key{tagExporterName}
+	exporterShardIDTags := []tag.Key{tagExporterName, tagShardID}
 
 	// There are some metrics enabled, return the views.
 
@@ -56,7 +57,7 @@ func metricViews() []*view.View {
 		Name:        statFlushedSpans.Name(),
 		Measure:     statFlushedSpans,
 		Description: statFlushedSpans.Description(),
-		TagKeys:     tagKeys,
+		TagKeys:     exporterShardIDTags,
 		Aggregation: view.Sum(),
 	}
 
@@ -64,7 +65,7 @@ func metricViews() []*view.View {
 		Name:        "omnishard_flushed_batches",
 		Measure:     statFlushedSpans,
 		Description: "number of batches flushed to omnishard exporter",
-		TagKeys:     tagKeys,
+		TagKeys:     exporterShardIDTags,
 		Aggregation: view.Count(),
 	}
 
@@ -72,7 +73,7 @@ func metricViews() []*view.View {
 		Name:        statFlushedSpansBytes.Name(),
 		Measure:     statFlushedSpansBytes,
 		Description: statFlushedSpansBytes.Description(),
-		TagKeys:     tagKeys,
+		TagKeys:     exporterShardIDTags,
 		Aggregation: view.LastValue(),
 	}
 
@@ -80,7 +81,7 @@ func metricViews() []*view.View {
 		Name:        statXLSpansBytes.Name(),
 		Measure:     statXLSpansBytes,
 		Description: statXLSpansBytes.Description(),
-		TagKeys:     tagKeys,
+		TagKeys:     exporterShardIDTags,
 		Aggregation: view.Sum(),
 	}
 
@@ -88,7 +89,7 @@ func metricViews() []*view.View {
 		Name:        "omnishard_xl_spans",
 		Measure:     statXLSpansBytes,
 		Description: "number of spans found that were larger than max supported size",
-		TagKeys:     tagKeys,
+		TagKeys:     exporterShardIDTags,
 		Aggregation: view.Count(),
 	}
 
@@ -96,7 +97,7 @@ func metricViews() []*view.View {
 		Name:        statEnqueuedSpans.Name(),
 		Measure:     statEnqueuedSpans,
 		Description: statEnqueuedSpans.Description(),
-		TagKeys:     tagKeys,
+		TagKeys:     exporterTags,
 		Aggregation: view.Sum(),
 	}
 
@@ -104,7 +105,7 @@ func metricViews() []*view.View {
 		Name:        "omnishard_enqueued_batches",
 		Measure:     statEnqueuedSpans,
 		Description: "batches received and put in a queue to be processed by omnishard exporter",
-		TagKeys:     tagKeys,
+		TagKeys:     exporterTags,
 		Aggregation: view.Count(),
 	}
 
@@ -112,7 +113,7 @@ func metricViews() []*view.View {
 		Name:        statDequeuedSpans.Name(),
 		Measure:     statDequeuedSpans,
 		Description: statDequeuedSpans.Description(),
-		TagKeys:     tagKeys,
+		TagKeys:     exporterTags,
 		Aggregation: view.Sum(),
 	}
 
@@ -120,7 +121,7 @@ func metricViews() []*view.View {
 		Name:        "omnishard_dequeued_batches",
 		Measure:     statDequeuedSpans,
 		Description: "batches taken out of queue and processed by omnishard exporter",
-		TagKeys:     tagKeys,
+		TagKeys:     exporterTags,
 		Aggregation: view.Count(),
 	}
 
@@ -128,13 +129,13 @@ func metricViews() []*view.View {
 		Name:        statCompressFactor.Name(),
 		Measure:     statCompressFactor,
 		Description: statCompressFactor.Description(),
-		TagKeys:     tagKeys,
+		TagKeys:     exporterShardIDTags,
 		Aggregation: view.LastValue(),
 	}
 
-	droppedTagKeys := make([]tag.Key, len(tagKeys)+1)
-	copy(droppedTagKeys, tagKeys)
-	droppedTagKeys[len(tagKeys)] = tagDropReason
+	droppedTagKeys := make([]tag.Key, len(exporterTags)+1)
+	copy(droppedTagKeys, exporterTags)
+	droppedTagKeys[len(exporterTags)] = tagDropReason
 
 	droppedSpansView := &view.View{
 		Name:        statDroppedSpans.Name(),
@@ -160,9 +161,9 @@ func metricViews() []*view.View {
 		Aggregation: view.Sum(),
 	}
 
-	sentTagKeys := make([]tag.Key, len(tagKeys)+1)
-	copy(sentTagKeys, tagKeys)
-	sentTagKeys[len(tagKeys)] = tagSendResult
+	sentTagKeys := make([]tag.Key, len(exporterTags)+1)
+	copy(sentTagKeys, exporterTags)
+	sentTagKeys[len(exporterTags)] = tagSendResult
 
 	sentSpansView := &view.View{
 		Name:        statSentSpans.Name(),


### PR DESCRIPTION
This is more for neatness since it doesn't change the metrics but avoid generating a bunch with empty label for shard ID and also adds the proper exporter name.